### PR TITLE
inferelator.R no longer needs to be run from the directory where it l…

### DIFF
--- a/R_scripts/summarize_results.R
+++ b/R_scripts/summarize_results.R
@@ -1,5 +1,20 @@
 library('Matrix')
-source('R_scripts/evaluate.R')
+
+thisFile <- function() {
+        cmdArgs <- commandArgs(trailingOnly = FALSE)
+        needle <- "--file="
+        match <- grep(needle, cmdArgs)
+        if (length(match) > 0) {
+                # Rscript
+                return(normalizePath(sub(needle, "", cmdArgs[match])))
+        } else {
+                # 'source'd via R console
+                return(normalizePath(sys.frames()[[1]]$ofile))
+        }
+}
+baseDirectory <- dirname(thisFile())
+
+source(paste(sep="/",baseDirectory,'R_scripts/evaluate.R'))
 
 get.mean.and.lh <- function(mat) {
   ret <- list()
@@ -62,7 +77,7 @@ sum.net <- function(betas, betas.resc, comb.confs, IN, cc.file, th=0.5) {
   cat('A total of', length(gp$pred.has.na), 'predictors contained NA and were removed.\n')
   cat('A total of', length(gp$pred.is.const), 'predictors were constant and were removed.\n')
   cat('A total of', length(unique(unlist(gp$pred.groups))), 'predictors formed', length(gp$pred.groups), 'groups.\n')
-  source('R_scripts/evaluate.R')
+  source(paste(sep="/",baseDirectory,'R_scripts/evaluate.R'))
   cc.aupr <- aupr(comb.confs, p.mat, eval.on.subset=TRUE)
   cat('AUPR is', cc.aupr, '\n')
 

--- a/R_scripts/vis_res_tfa.R
+++ b/R_scripts/vis_res_tfa.R
@@ -1,5 +1,21 @@
 library('Matrix')
-source('R_scripts/priors.R')
+
+# Get the directory in which inferelator.R sits
+thisFile <- function() {
+        cmdArgs <- commandArgs(trailingOnly = FALSE)
+        needle <- "--file="
+        match <- grep(needle, cmdArgs)
+        if (length(match) > 0) {
+                # Rscript
+                return(normalizePath(sub(needle, "", cmdArgs[match])))
+        } else {
+                # 'source'd via R console
+                return(normalizePath(sys.frames()[[1]]$ofile))
+        }
+}
+baseDirectory <- dirname(thisFile())
+
+source(paste(sep="/",baseDirectory,'R_scripts/priors.R'))
 
 ChristophsPR <- function(ord.idx, gs) {
   prec <- cumsum(gs[ord.idx]) / cumsum(rep(1, length(ord.idx)))

--- a/inferelator.R
+++ b/inferelator.R
@@ -10,17 +10,32 @@ library('Matrix')
 rm(list=ls())
 gc()
 
-source('R_scripts/utils.R')
-source('R_scripts/design_and_response.R')
-source('R_scripts/priors.R')
-source('R_scripts/mi_and_clr.R')
-source('R_scripts/bayesianRegression.R')
-source('R_scripts/men.R')
-source('R_scripts/evaluate.R')
-source('R_scripts/tfa.R')
-source('R_scripts/group_predictors.R')
-source('R_scripts/summarize_results.R')
-source('R_scripts/vis_tfs_and_targets.R')
+# Get the directory in which inferelator.R sits
+thisFile <- function() {
+        cmdArgs <- commandArgs(trailingOnly = FALSE)
+        needle <- "--file="
+        match <- grep(needle, cmdArgs)
+        if (length(match) > 0) {
+                # Rscript
+                return(normalizePath(sub(needle, "", cmdArgs[match])))
+        } else {
+                # 'source'd via R console
+                return(normalizePath(sys.frames()[[1]]$ofile))
+        }
+}
+baseDirectory <- dirname(thisFile())
+
+source(paste(sep="/", baseDirectory, 'R_scripts/utils.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/design_and_response.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/priors.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/mi_and_clr.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/bayesianRegression.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/men.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/evaluate.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/tfa.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/group_predictors.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/summarize_results.R'))
+source(paste(sep="/", baseDirectory, 'R_scripts/vis_tfs_and_targets.R'))
 
 
 date.time.str <- format(Sys.time(), "%Y-%m-%d_%H-%M-%S")
@@ -429,7 +444,7 @@ PROCTIME <- proc.time() - start.proc.time
 save(PARS, IN, SEED, PROCTIME, file = paste(PARS$save.to.dir, "/params_and_input.RData", sep=""))
 
 # generate network report and visualize TFs and targets
-source('R_scripts/net_report_new.R')
+source(paste(sep="/", baseDirectory, 'R_scripts/net_report_new.R'))
 Sys.sleep(2)
 for (ccf in list.files(PARS$save.to.dir, pattern='combinedconf_*', full.names=TRUE)) {
   if (PARS$output.report) {


### PR DESCRIPTION
Paths in Inferelator for sourcing local scripts were hard coded. This required inferelator.R to be run from the directory in which it lives. This change uses a function to find the directory in which inferelator.R lives and prepends it to each of the 'source()' statements in the code, allowing it to be executed anywhere on the filesystem.